### PR TITLE
Fix typo in intro groups

### DIFF
--- a/ConstructionZone/IntroGroups.tex
+++ b/ConstructionZone/IntroGroups.tex
@@ -1380,7 +1380,7 @@ Let $G$ be a group with generating set $S$ and consider the corresponding Cayley
 \[
 s_{1}^{\epsilon_1}s_{2}^{\epsilon_2}\cdots s_{n}^{\epsilon_n}=t_{1}^{\delta_1}t_{2}^{\delta_2}\cdots t_{m}^{\delta_m}
 \]
-is a relation in $G$, where each $s_{i},t_{j}\S$ and $\epsilon_i,\delta_j\in\{\pm 1\}$.  Explain what it means for this relation to hold globally across the entire Cayley diagram for $G$.
+is a relation in $G$, where each $s_{i},t_{j}\in S$ and $\epsilon_i,\delta_j\in\{\pm 1\}$.  Explain what it means for this relation to hold globally across the entire Cayley diagram for $G$.
 \end{problem}
 
 You've likely noticed the following theorem while tinkering with examples.


### PR DESCRIPTION
There was a section symbol showing up where there should have been `\in S`.