### PR TITLE
Fix critical error in Cayley diagram in Prob 2.74

### DIFF
--- a/ConstructionZone/IntroGroups.tex
+++ b/ConstructionZone/IntroGroups.tex
@@ -1195,14 +1195,14 @@ The Cayley diagrams of two groups of order $12$ are shown below.
 \node (aaa) at (3,2.5) [vert] {\scriptsize $s^3$};
 %%
 \node (b) at (0,1.25) [vert] {\scriptsize $t$};
-\node (ba) at (1,1.25) [vert] {\scriptsize $ts$};
-\node (aab) at (2,1.25) [vert] {\scriptsize $s^2\!t$};
-\node (abb) at (3,1.25) [vert] {\scriptsize $st^2$};
+\node (ba) at (1,1.25) [vert] {\scriptsize $st$};
+\node (aab) at (2,1.25) [vert] {\scriptsize $ts^2$};
+\node (abb) at (3,1.25) [vert] {\scriptsize $t^2\! s$};
 %%
 \node (bb) at (0,0) [vert] {\scriptsize $t^2$};
-\node (bba) at (1,0) [vert] {\scriptsize $t^2\!s$};
-\node (aabb) at (2,0) [vert] {\scriptsize $s^2\!t^2$};
-\node (ab) at (3,0) [vert] {\scriptsize $st$};
+\node (bba) at (1,0) [vert] {\scriptsize $st^2$};
+\node (aabb) at (2,0) [vert] {\scriptsize $t^2\!s^2$};
+\node (ab) at (3,0) [vert] {\scriptsize $ts$};
 %%
 \draw [o] (e) to (a); \draw [o] (a) to (aa);
 \draw [o] (aa) to (aaa); \draw [o] (aaa) to [bend right=25] (e);


### PR DESCRIPTION
The s's and t's were all backward in the labels on the group elements in the first Cayley diagram in Problem 2.74, which I didn't realize until I sent my students off to work on it and then we were comparing things in class and they had some serious befuddlement. (Paradoxically, the "harder" second one worked out better, since it didn't have the issue.)